### PR TITLE
Disable validif generation by default

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -71,6 +71,7 @@ yargs
   .option('numMods',      {type: 'number',              default: 5,     desc: 'number of modules'})
   .option('numClocks',    {type: 'number',  alias: 'c', default: 2,     desc: 'number of clocks'})
   .option('unusedMods',   {type: 'boolean',             default: false, desc: 'allow unused modules'})
+  .option('validif',      {type: 'boolean',             default: false, desc: 'validif'})
   .command({
     command: 'fir',
     aliases: ['firrtl'],

--- a/lib/fir-gen-validif.js
+++ b/lib/fir-gen-validif.js
@@ -9,6 +9,9 @@ const wireRegOutput = require('./fir-wire-reg-output.js');
 const getClockName = require('./fir-get-clock-name.js');
 
 const genValidif = (mt, opt) => nodes => {
+  if (!opt.validif) {
+    return;
+  }
   const args = [0, 1].map(() => rndNode(mt, nodes, opt));
   const width = args[1].width;
 


### PR DESCRIPTION
This PR adds a command line option that disables `validif` generation by default.

CIRCT removed support for the `validif` construct following its removal from the FIRRTL spec:
- https://github.com/llvm/circt/commit/3682999e35577c4c56d34cc6e7f390befe6c07c1
- https://github.com/chipsalliance/firrtl-spec/pull/57

---

As an aside, I was looking for an opportunity to extend your work on fuzzing CIRCT. Since I'm relatively new to the CIRCT project, I wanted to ask if you had any guidance to share regarding what the community might find useful? I would be grateful for your advice.